### PR TITLE
fix: GPU analysis over-compressing all textures when editor GUI is repainted mid-build (VRCFury)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Not reflected in the inspector preview (it requires the NDMF build context); the preview shows a notice while the feature is enabled
   - Enabled by default, toggleable per avatar in the inspector
 
+### Fixed
+
+- **GPU analysis no longer breaks when other tools repaint the editor GUI during the build** - Coexisting build tools that synchronously repaint an editor window mid-build (e.g. VRCFury's progress window during play-mode builds) corrupted the editor graphics state so that compute shaders silently read all-zero pixels from RenderTextures, collapsing every sRGB texture's complexity to the sparse-texture penalty (10%) and over-compressing the whole avatar to minimum resolution
+  - The GPU backend now binds sRGB textures directly to the compute shader instead of pre-blitting them into a linear RenderTexture; `*_SRGB` texture formats decode to linear in hardware even for `Load()`, and direct texture binds are unaffected by the corruption
+  - Also removes the per-texture RenderTexture allocation, and sRGB pixel values are no longer quantized to 8-bit before analysis
+
 ## [v0.8.0] - 2026-05-01
 
 ### Added

--- a/Editor/TextureCompressor/Analysis/Backends/GpuAnalysisBackend.cs
+++ b/Editor/TextureCompressor/Analysis/Backends/GpuAnalysisBackend.cs
@@ -101,9 +101,7 @@ namespace dev.limitex.avatar.compressor.editor.texture
                     Texture2D Tex,
                     AsyncGPUReadbackRequest Request,
                     ComputeBuffer ResultBuf,
-                    ComputeBuffer IntermediateBuf,
-                    TextureInfo Info,
-                    RenderTexture LinearRT
+                    ComputeBuffer IntermediateBuf
                 )>();
 
             try
@@ -130,45 +128,22 @@ namespace dev.limitex.avatar.compressor.editor.texture
                         sizeof(uint)
                     );
 
-                    RenderTexture linearRT = null;
-
                     try
                     {
-                        // For sRGB textures, blit to a linear RenderTexture to ensure
-                        // consistent sRGB-to-linear conversion across all platforms.
-                        // This matches the CPU path (Graphics.Blit auto-decodes sRGB)
-                        // and avoids platform-dependent Load() behavior in compute shaders.
-                        Texture sourceTexture = texture;
-                        if (texture.isDataSRGB)
-                        {
-                            linearRT = new RenderTexture(
-                                texture.width,
-                                texture.height,
-                                0,
-                                RenderTextureFormat.ARGB32,
-                                RenderTextureReadWrite.Linear
-                            );
-                            linearRT.Create();
-                            var prev = RenderTexture.active;
-                            try
-                            {
-                                Graphics.Blit(texture, linearRT);
-                            }
-                            finally
-                            {
-                                RenderTexture.active = prev;
-                            }
-                            sourceTexture = linearRT;
-                        }
+                        // sRGB textures are bound directly: *_SRGB SRV formats decode to
+                        // linear in hardware even for Load(), so no shader-side conversion
+                        // or pre-blit is needed. Routing them through a Graphics.Blit
+                        // RenderTexture must be avoided here: editor GUI interference
+                        // (e.g. VRCFury synchronously repainting its progress window during
+                        // play-mode builds) can silently zero out RenderTexture reads in
+                        // compute shaders while leaving direct texture binds intact.
 
                         // Clear intermediate buffer
                         intermediateBuffer.SetData(Zeros);
 
                         // Set shared parameters
                         SetSharedParameters(
-                            sourceTexture,
-                            texture.width,
-                            texture.height,
+                            texture,
                             sampledWidth,
                             sampledHeight,
                             info.IsNormalMap,
@@ -181,16 +156,12 @@ namespace dev.limitex.avatar.compressor.editor.texture
 
                         // Queue async readback
                         var request = AsyncGPUReadback.Request(resultBuffer);
-                        pendingReadbacks.Add(
-                            (texture, request, resultBuffer, intermediateBuffer, info, linearRT)
-                        );
-                        linearRT = null; // Ownership transferred to pendingReadbacks
+                        pendingReadbacks.Add((texture, request, resultBuffer, intermediateBuffer));
                     }
                     catch (System.Exception e)
                     {
                         ReleaseBuffer(resultBuffer);
                         ReleaseBuffer(intermediateBuffer);
-                        DestroyRT(linearRT);
                         Debug.LogWarning(
                             $"[TextureCompressor] GPU analysis failed for '{texture.name}': {e.Message}"
                         );
@@ -223,7 +194,6 @@ namespace dev.limitex.avatar.compressor.editor.texture
                 {
                     ReleaseBuffer(pending.ResultBuf);
                     ReleaseBuffer(pending.IntermediateBuf);
-                    DestroyRT(pending.LinearRT);
                 }
             }
 
@@ -231,9 +201,7 @@ namespace dev.limitex.avatar.compressor.editor.texture
         }
 
         private void SetSharedParameters(
-            Texture sourceTexture,
-            int sourceWidth,
-            int sourceHeight,
+            Texture2D texture,
             int sampledWidth,
             int sampledHeight,
             bool isNormalMap,
@@ -243,8 +211,8 @@ namespace dev.limitex.avatar.compressor.editor.texture
         {
             _shader.SetInt("_Width", sampledWidth);
             _shader.SetInt("_Height", sampledHeight);
-            _shader.SetInt("_SourceWidth", sourceWidth);
-            _shader.SetInt("_SourceHeight", sourceHeight);
+            _shader.SetInt("_SourceWidth", texture.width);
+            _shader.SetInt("_SourceHeight", texture.height);
             _shader.SetInt("_IsNormalMap", isNormalMap ? 1 : 0);
             _shader.SetInt("_StrategyType", GetStrategyIndex());
 
@@ -324,7 +292,7 @@ namespace dev.limitex.avatar.compressor.editor.texture
 
             foreach (int kernel in allKernels)
             {
-                _shader.SetTexture(kernel, "_InputTexture", sourceTexture);
+                _shader.SetTexture(kernel, "_InputTexture", texture);
                 _shader.SetBuffer(kernel, "_ResultBuffer", resultBuffer);
                 _shader.SetBuffer(kernel, "_IntermediateBuffer", intermediateBuffer);
             }
@@ -561,23 +529,6 @@ namespace dev.limitex.avatar.compressor.editor.texture
             {
                 Debug.LogWarning(
                     $"[TextureCompressor] Failed to release ComputeBuffer: {e.Message}"
-                );
-            }
-        }
-
-        private static void DestroyRT(RenderTexture rt)
-        {
-            if (rt == null)
-                return;
-            try
-            {
-                rt.Release();
-                Object.DestroyImmediate(rt);
-            }
-            catch (System.Exception e)
-            {
-                Debug.LogWarning(
-                    $"[TextureCompressor] Failed to destroy RenderTexture: {e.Message}"
                 );
             }
         }

--- a/Editor/TextureCompressor/Analysis/Shaders/TextureAnalysisCommon.hlsl
+++ b/Editor/TextureCompressor/Analysis/Shaders/TextureAnalysisCommon.hlsl
@@ -103,8 +103,8 @@ RWStructuredBuffer<uint> _IntermediateBuffer;
 
 // Sample a pixel at sampled-space coordinates using nearest-neighbor.
 // Matches CPU PixelSampler.SampleIfNeeded index math for identical results.
-// sRGB-to-linear conversion is handled on the C# side by blitting sRGB textures
-// to a linear RenderTexture before binding, so no shader-side conversion is needed.
+// sRGB textures are bound directly; *_SRGB SRV formats decode to linear in
+// hardware even for Load(), so no shader-side conversion is needed.
 float4 SamplePixel(uint sx, uint sy)
 {
     float xStep = (float)_SourceWidth / (float)_Width;

--- a/Editor/TextureCompressor/Core/Services/TextureProcessor.cs
+++ b/Editor/TextureCompressor/Core/Services/TextureProcessor.cs
@@ -235,7 +235,7 @@ namespace dev.limitex.avatar.compressor.editor.texture
         /// For non-readable or sRGB textures, performs GPU→CPU readback via RenderTexture.
         /// sRGB textures always go through the blit path with an explicit linear RT
         /// so that hardware sRGB-to-linear decode is applied, matching the GPU analysis
-        /// backend which also blits sRGB textures to a linear RenderTexture.
+        /// backend which gets the same hardware decode by binding sRGB textures directly.
         /// The temporary resources are released immediately, keeping peak memory low.
         /// </summary>
         public Color[] GetReadablePixelsSingle(Texture2D texture)
@@ -270,7 +270,7 @@ namespace dev.limitex.avatar.compressor.editor.texture
                     // so that native GPU memory is freed immediately by DestroyImmediate,
                     // rather than being held in Unity's RT pool across calls.
                     // Force Linear color space so that sRGB textures are decoded to linear
-                    // by the hardware during blit, matching the GPU analysis backend.
+                    // by the hardware during blit.
                     rt = new RenderTexture(
                         texture.width,
                         texture.height,

--- a/Tests/Editor/Analysis/Backends/GpuCpuParityTests.cs
+++ b/Tests/Editor/Analysis/Backends/GpuCpuParityTests.cs
@@ -17,9 +17,10 @@ namespace dev.limitex.avatar.compressor.tests
     {
         private const float ScoreTolerance = 0.02f;
 
-        // sRGB textures use slightly wider tolerance than linear because GPU pow()
-        // and CPU hardware sRGB decode may differ by a few ULP at float32 precision.
-        // With the exact piecewise formula on GPU, divergence is typically <0.02.
+        // sRGB textures use slightly wider tolerance than linear: both backends rely
+        // on hardware sRGB decode, but the CPU path quantizes the decoded values to
+        // 8-bit via its ARGB32 RenderTexture readback while the GPU path reads the
+        // decoded values at full precision directly from the source texture.
         private const float SRGBScoreTolerance = 0.03f;
         private const string ShaderPath =
             "Packages/dev.limitex.avatar-compressor/"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPU analysis so it no longer breaks when other build-time tools repaint the editor GUI mid-build.
  * Updated GPU analysis to bind sRGB textures directly for compute, improving stability and avoiding problematic intermediate render targets.
* **Documentation**
  * Updated the changelog entry under **Unreleased → Fixed**.
* **Tests**
  * Clarified the reason for using a wider tolerance in GPU vs CPU texture comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->